### PR TITLE
Added support for a second modbus meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See sample-configuration.yaml for information how to configure, and how to extra
 
 # Enable readings from external RS485 meter
 
-Just add "read_meter1: true" to the configuration block. For now it only supports one external meter for getting values such as current (own) power consumption, grid power, etc.... so you can calculate your own consumption from the solar panels and import/export for example. Thanks to [awulf](https://github.com/awulf) for contributing with code and testing for this feature.
+Just add "read_meter1: true" to the configuration block. If you have an additional meter, add "read_meter2: true". For now it only supports two external meter for getting values such as current (own) power consumption, grid power, etc.... so you can calculate your own consumption from the solar panels and import/export for example. Thanks to [awulf](https://github.com/awulf) for contributing with code and testing for this feature. Thanks to [magpern](https://github.com/magpern) for adding support for a second meter.
 
 
 

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -17,6 +17,7 @@ CONFIG_SCHEMA = vol.Schema(
         vol.Optional("port", default=1502): cv.positive_int,
         vol.Optional(CONF_SCAN_INTERVAL, default=1): cv.positive_int,
         vol.Optional("read_meter1", default=False): cv.boolean,
+        vol.Optional("read_meter2", default=False): cv.boolean,
     })},
     extra=vol.ALLOW_EXTRA,
 )
@@ -39,6 +40,6 @@ async def async_setup(hass, config):
     _LOGGER.debug("creating modbus client done")
 
     for component in ["sensor"]:
-        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"]}, config)
+        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"], "read_meter2": conf["read_meter2"]}, config)
 
     return True

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -24,6 +24,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 
 values = {}
 meter1_values = {}
+meter2_values = {}
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     if discovery_info is None:
@@ -33,12 +34,15 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     client = hass.data.get(SOLAREDGE_DOMAIN)
     scan_interval = discovery_info[CONF_SCAN_INTERVAL]
     useMeter1 = discovery_info["read_meter1"]
+    useMeter2 = discovery_info["read_meter2"]
 
     async_add_entities([SolarEdgeModbusSensor(client, scan_interval)], True)
 
     if useMeter1:
         async_add_entities([SolarEdgeMeterSensor(client, scan_interval)], True)
 
+    if useMeter2:
+        async_add_entities([SolarEdgeMeterSensor2(client, scan_interval)], True)
 
 class SolarEdgeModbusSensor(Entity):
     def __init__(self, client, scan_interval):
@@ -238,7 +242,6 @@ class SolarEdgeModbusSensor(Entity):
     @property
     def unique_id(self):
         return "SolarEdge"
-
 
 class SolarEdgeMeterSensor(Entity):
     def __init__(self, client, scan_interval):
@@ -496,3 +499,260 @@ class SolarEdgeMeterSensor(Entity):
     @property
     def unique_id(self):
         return "SolarEdge Meter#1"
+
+class SolarEdgeMeterSensor2(Entity):
+    def __init__(self, client, scan_interval):
+        _LOGGER.debug("creating modbus meter#2 sensor")
+        print("creating modbus meter#2 sensor")
+
+        self._client = client
+
+        self._scan_interval = scan_interval
+        self._state = 0
+        self._device_state_attributes = {}
+
+    def round(self, floatval):
+        return round(floatval, 2)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._device_state_attributes
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+
+    async def async_added_to_hass(self):
+        _LOGGER.debug("added to hass, starting loop")
+        loop = self.hass.loop
+        task = loop.create_task(self.modbus_loop())
+
+    async def modbus_loop(self):
+        while True:
+            sleep(0.005)
+            try:
+		        
+                reading = self._client.read_holding_registers(40362, 107)
+                
+                if reading:
+                    data = BinaryPayloadDecoder.fromRegisters(reading, byteorder=Endian.Big, wordorder=Endian.Big)
+
+                    # Identification
+                    # 40188 C_SunSpec_DID (unit16)
+                    # 40189 C_SunSpec_Length (unit16)
+                    data.skip_bytes(4)
+
+                    # Current
+                    # #40190 - #40193
+                    m1_ac_current = data.decode_16bit_int()
+                    m1_ac_current_phase_a = data.decode_16bit_int()
+                    m1_ac_current_phase_b = data.decode_16bit_int()
+                    m1_ac_current_phase_c = data.decode_16bit_int()
+                    
+                    # #40194
+                    m1_ac_current_scalefactor = 10**data.decode_16bit_int()
+
+                    meter2_values['ac_current'] = self.round(m1_ac_current * m1_ac_current_scalefactor)
+                    meter2_values['ac_current_phase_a'] = self.round(m1_ac_current_phase_a * m1_ac_current_scalefactor)
+                    meter2_values['ac_current_phase_b'] = self.round(m1_ac_current_phase_b * m1_ac_current_scalefactor)
+                    meter2_values['ac_current_phase_c'] = self.round(m1_ac_current_phase_c * m1_ac_current_scalefactor)
+
+                    ################
+                    # Voltage
+                    ################
+
+                    #40195-40198, AC Voltage LN, AB, BC and CA
+                    m1_ac_voltage_phase_ln = data.decode_16bit_uint()
+                    m1_ac_voltage_phase_an = data.decode_16bit_uint()
+                    m1_ac_voltage_phase_bn = data.decode_16bit_uint()
+                    m1_ac_voltage_phase_cn = data.decode_16bit_uint()
+
+                    #40199-40202, AC Voltage LN, AN, BN and CN
+                    m1_ac_voltage_phase_ll = data.decode_16bit_uint()
+                    m1_ac_voltage_phase_ab = data.decode_16bit_uint()
+                    m1_ac_voltage_phase_bc = data.decode_16bit_uint()
+                    m1_ac_voltage_phase_ca = data.decode_16bit_uint()
+
+                    #40203
+                    m1_ac_voltage_phase_scalefactor = 10**data.decode_16bit_int()
+
+                    meter2_values['ac_voltage_phase_ll'] = self.round(m1_ac_voltage_phase_ll * m1_ac_voltage_phase_scalefactor)
+                    meter2_values['ac_voltage_phase_ab'] = self.round(m1_ac_voltage_phase_ab * m1_ac_voltage_phase_scalefactor)
+                    meter2_values['ac_voltage_phase_bc'] = self.round(m1_ac_voltage_phase_bc * m1_ac_voltage_phase_scalefactor)
+                    meter2_values['ac_voltage_phase_ca'] = self.round(m1_ac_voltage_phase_ca * m1_ac_voltage_phase_scalefactor)
+        
+                    meter2_values['ac_voltage_phase_ln'] = self.round(m1_ac_voltage_phase_ln * m1_ac_voltage_phase_scalefactor)
+                    meter2_values['ac_voltage_phase_an'] = self.round(m1_ac_voltage_phase_an * m1_ac_voltage_phase_scalefactor)
+                    meter2_values['ac_voltage_phase_bn'] = self.round(m1_ac_voltage_phase_bn * m1_ac_voltage_phase_scalefactor)
+                    meter2_values['ac_voltage_phase_cn'] = self.round(m1_ac_voltage_phase_cn * m1_ac_voltage_phase_scalefactor)
+
+                    #40204, Frequency
+                    m1_ac_frequency = data.decode_16bit_int()
+
+                    ################
+                    # Power
+                    ################
+
+                    #40205
+                    m1_ac_frequency_scalefactor = 10**data.decode_16bit_int()
+                    meter2_values['ac_frequency'] = self.round(m1_ac_frequency * m1_ac_frequency_scalefactor)
+
+                    #40206
+                    m1_ac_power_output = data.decode_16bit_int()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    #40210
+                    m1_ac_power_scalefactor = 10**data.decode_16bit_int()
+                    meter2_values['ac_power_output'] = self.round(m1_ac_power_output * m1_ac_power_scalefactor)
+
+                    #40211 Apparent Power
+                    m1_ac_va = data.decode_16bit_uint()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    m1_ac_va_scalefactor = 10 ** data.decode_16bit_int()
+                    meter2_values['ac_va'] = self.round(m1_ac_va * m1_ac_va_scalefactor)
+
+                    #40216 Reactive Power
+                    m1_ac_var = data.decode_16bit_uint()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    m1_ac_var_scalefactor = 10 ** data.decode_16bit_int()
+                    meter2_values['ac_var'] = self.round(m1_ac_var * m1_ac_var_scalefactor)
+
+                    #40221 Power Factor
+                    m1_ac_pf = data.decode_16bit_uint()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    m1_ac_pf_scalefactor = 10 ** data.decode_16bit_int()
+                    meter2_values['ac_pf'] = self.round(m1_ac_pf * m1_ac_pf_scalefactor)
+
+                    ################
+                    # Accumulated Energy
+                    ################
+
+                    # Real Energy
+                    # ---------------
+
+                    #40226
+                    m1_exported = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+                    
+                    #40234
+                    m1_imported = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40095
+                    m1_energy_scalefactor = 10**data.decode_16bit_uint()
+
+                    # Total production entire lifetime
+                    meter2_values['exported'] = self.round(m1_exported * m1_energy_scalefactor)
+                    meter2_values['imported'] = self.round(m1_imported * m1_energy_scalefactor)
+
+                    # Apparent Energy
+                    # ---------------
+
+                    #40243
+                    m1_exported_va = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+                    
+                    #40251
+                    m1_imported_va = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40259
+                    m1_energy_va_scalefactor = 10**data.decode_16bit_uint()
+
+                    # Total production entire lifetime
+                    meter2_values['exported_va'] = self.round(m1_exported_va * m1_energy_va_scalefactor)
+                    meter2_values['imported_va'] = self.round(m1_imported_va * m1_energy_va_scalefactor)
+
+                    # Reactive Energy
+                    # ---------------
+
+                    #40260
+                    m1_imported_var_q1 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+                    
+                    #40268
+                    m1_imported_var_q2 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40276
+                    m1_exported_var_q3 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40284
+                    m1_exported_var_q4 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40293
+                    m1_energy_var_scalefactor = 10**data.decode_16bit_uint()
+
+                    # Total production entire lifetime
+                    meter2_values['imported_var_q1'] = self.round(m1_imported_var_q1 * m1_energy_var_scalefactor)
+                    meter2_values['imported_var_q2'] = self.round(m1_imported_var_q2 * m1_energy_var_scalefactor)
+                    meter2_values['exported_var_q3'] = self.round(m1_exported_var_q3 * m1_energy_var_scalefactor)
+                    meter2_values['exported_var_q4'] = self.round(m1_exported_var_q4 * m1_energy_var_scalefactor)
+                    
+                    # Events
+                    # ---------------
+
+                    #40097 
+                    m1_events = data.decode_32bit_uint()
+                    meter2_values['events'] = m1_events
+
+                    # M_EVENT_Power_Failure 0x00000004 Loss of power or phase
+                    # M_EVENT_Under_Voltage 0x00000008 Voltage below threshold (Phase Loss)
+                    # M_EVENT_Low_PF 0x00000010 Power Factor below threshold (can indicate miss-associated voltage and current inputs in three phase systems)
+                    # M_EVENT_Over_Current 0x00000020 Current Input over threshold (out of measurement range)
+                    # M_EVENT_Over_Voltage 0x00000040 Voltage Input over threshold (out of measurement range)
+                    # M_EVENT_Missing_Sensor 0x00000080 Sensor not connected
+
+                    
+                    self._state = meter2_values['ac_power_output']
+                    self._device_state_attributes = meter2_values
+
+                    #tell HA there is new data
+                    self.async_schedule_update_ha_state()
+                
+                
+                else:
+                    if self._client.last_error() > 0:
+                        _LOGGER.error(f'error {self._client.last_error()}')
+
+            except Exception as e:
+                _LOGGER.error(f'exception: {e}')
+                print(traceback.format_exc())
+
+            await asyncio.sleep(self._scan_interval)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "SolarEdge Modbus Meter #2"
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return ICON
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return "W"
+
+    @property
+    def unique_id(self):
+        return "SolarEdge Meter#2"


### PR DESCRIPTION
Added support for a second modbus meter. Solaredge supports up to three meters.
This was pretty much a copy paste job, and it could probably be made more pretty by extracting the data collection in a shared function and calling it with parameters. The only difference between meters is the modbus start address.
But, my python knowledge is limited, and this PR solves the problem with two meters.

![image](https://user-images.githubusercontent.com/6589760/91640642-69e93b80-ea1f-11ea-87be-5181a4ee2c3a.png)
 