### PR TITLE
Fixed some cast errors and added modbus unit id

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -15,6 +15,7 @@ CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default="SolarEdge Modbus"): cv.string,
         vol.Optional("port", default=1502): cv.positive_int,
+        vol.Optional("unit_id", default=1): cv.positive_int,
         vol.Optional(CONF_SCAN_INTERVAL, default=1): cv.positive_int,
         vol.Optional("read_meter1", default=False): cv.boolean,
         vol.Optional("read_meter2", default=False): cv.boolean,
@@ -34,8 +35,9 @@ async def async_setup(hass, config):
 
     host = conf[CONF_HOST]
     port = conf["port"]
+    unit_id = conf["unit_id"]
 
-    client = ModbusClient(host, port=port, unit_id=1, auto_open=True)
+    client = ModbusClient(host, port=port, unit_id=unit_id, auto_open=True)
     hass.data[DOMAIN] = client
 
     _LOGGER.debug("creating modbus client done")

--- a/custom_components/solaredge_modbus/meter_sensor.py
+++ b/custom_components/solaredge_modbus/meter_sensor.py
@@ -17,12 +17,16 @@ from homeassistant.helpers.entity import Entity
 
 from . import DOMAIN as SOLAREDGE_DOMAIN
 
+_LOGGER = logging.getLogger(__name__)
+
+ICON = "mdi:power-plug"
+
 meter_values = {}
 
 class SolarEdgeMeterSensor(Entity):
     def __init__(self, client, unit_id, scan_interval):
-        _LOGGER.debug("creating modbus meter sensor #" + unit_id)
-        print("creating modbus meter sensor #" + unit_id)
+        _LOGGER.debug("creating modbus meter sensor #" + str(unit_id))
+        print("creating modbus meter sensor #" + str(unit_id))
 
         self._client = client
 
@@ -33,9 +37,9 @@ class SolarEdgeMeterSensor(Entity):
         self._register_start = 40188
 
         if unit_id == 2:
-            self._register_start = 40632
+            self._register_start = 40362
         elif unit_id == 3:
-            self._register_start = 40537
+            self._register_start = 40536
 
     def round(self, floatval):
         return round(floatval, 2)
@@ -60,7 +64,6 @@ class SolarEdgeMeterSensor(Entity):
         while True:
             sleep(0.005)
             try:
-		        
                 reading = self._client.read_holding_registers(self._register_start, 107)
                 
                 if reading:
@@ -262,7 +265,7 @@ class SolarEdgeMeterSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "SolarEdge Modbus Meter #" + self._unit_id
+        return "SolarEdge Modbus Meter #" + str(self._unit_id)
 
     @property
     def should_poll(self):
@@ -281,4 +284,4 @@ class SolarEdgeMeterSensor(Entity):
 
     @property
     def unique_id(self):
-        return "SolarEdge Meter#" + self._unit_id
+        return "SolarEdge Meter#" + str(self._unit_id)


### PR DESCRIPTION
string and integer cannot be concatenated without cast. - fixed
LOGGER was missing in meter_sensor.py - fixed
ICON was missing - fixed
Modbus registers was wrong - fixed (meter 3 is not tested)

Added modbus unit id to config
Default is modbus id 1, but in my case allowing Victron VenusOS to read my SolarEdge, I had to change to unit_id 126

Tested with Solaredge SE17K and two external meters.
![image](https://user-images.githubusercontent.com/6589760/112771110-83d91400-902a-11eb-8ab1-480ff0c29ae8.png)

Fixes #17 