### PR TITLE
Multiple inverters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+custom_components/solaredge_modbus/__pycache__
+**.py.save

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -2,29 +2,36 @@ import logging
 
 import voluptuous as vol
 
-from pyModbusTCP.client import ModbusClient
+from pymodbus.client.sync import ModbusTcpClient
 
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SCAN_INTERVAL
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import discovery
 
-DOMAIN="solaredge_modbus"
+DOMAIN = "solaredge_modbus"
 
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: vol.Schema({
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default="SolarEdge Modbus"): cv.string,
-        vol.Optional("port", default=1502): cv.positive_int,
-        vol.Optional(CONF_SCAN_INTERVAL, default=1): cv.positive_int,
-        vol.Optional("read_meter1", default=False): cv.boolean,
-        vol.Optional("read_meter2", default=False): cv.boolean,
-        vol.Optional("read_meter3", default=False): cv.boolean,
-    })},
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_HOST): cv.string,
+                vol.Optional(CONF_NAME, default="SolarEdge Modbus"): cv.string,
+                vol.Optional("port", default=1502): cv.positive_int,
+                vol.Optional("unit_id", default=1): cv.positive_int,
+                vol.Optional(CONF_SCAN_INTERVAL, default=1): cv.positive_int,
+                vol.Optional("read_meter1", default=False): cv.boolean,
+                vol.Optional("read_meter2", default=False): cv.boolean,
+                vol.Optional("read_meter3", default=False): cv.boolean,
+                vol.Optional("additional_inverter_unit_id", default=0): cv.positive_int,
+            }
+        )
+    },
     extra=vol.ALLOW_EXTRA,
 )
 
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup(hass, config):
     """Set up the SolarEdge component."""
@@ -35,12 +42,26 @@ async def async_setup(hass, config):
     host = conf[CONF_HOST]
     port = conf["port"]
 
-    client = ModbusClient(host, port=port, unit_id=1, auto_open=True)
+    client = ModbusTcpClient(host, port=port, auto_open=True)
     hass.data[DOMAIN] = client
 
     _LOGGER.debug("creating modbus client done")
 
     for component in ["sensor"]:
-        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"], "read_meter2": conf["read_meter2"], "read_meter3": conf["read_meter3"]}, config)
+        discovery.load_platform(
+            hass,
+            component,
+            DOMAIN,
+            {
+                CONF_NAME: DOMAIN,
+                "unit_id": conf["unit_id"],
+                CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL],
+                "read_meter1": conf["read_meter1"],
+                "read_meter2": conf["read_meter2"],
+                "read_meter3": conf["read_meter3"],
+                "additional_inverter_unit_id": conf["additional_inverter_unit_id"],
+            },
+            config,
+        )
 
     return True

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -15,9 +15,10 @@ CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default="SolarEdge Modbus"): cv.string,
         vol.Optional("port", default=1502): cv.positive_int,
-        vol.Optional("unit_id", default=1): cv.positive_int,
         vol.Optional(CONF_SCAN_INTERVAL, default=1): cv.positive_int,
         vol.Optional("read_meter1", default=False): cv.boolean,
+        vol.Optional("read_meter2", default=False): cv.boolean,
+        vol.Optional("read_meter3", default=False): cv.boolean,
     })},
     extra=vol.ALLOW_EXTRA,
 )
@@ -40,6 +41,6 @@ async def async_setup(hass, config):
     _LOGGER.debug("creating modbus client done")
 
     for component in ["sensor"]:
-        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"], unit_id: conf["unit_id"]}, config)
+        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"], "read_meter2": conf["read_meter2"], "read_meter3": conf["read_meter3"]}, config)
 
     return True

--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -15,6 +15,7 @@ CONFIG_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_NAME, default="SolarEdge Modbus"): cv.string,
         vol.Optional("port", default=1502): cv.positive_int,
+        vol.Optional("unit_id", default=1): cv.positive_int,
         vol.Optional(CONF_SCAN_INTERVAL, default=1): cv.positive_int,
         vol.Optional("read_meter1", default=False): cv.boolean,
     })},
@@ -39,6 +40,6 @@ async def async_setup(hass, config):
     _LOGGER.debug("creating modbus client done")
 
     for component in ["sensor"]:
-        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"]}, config)
+        discovery.load_platform(hass, component, DOMAIN, {CONF_NAME: DOMAIN, CONF_SCAN_INTERVAL: conf[CONF_SCAN_INTERVAL], "read_meter1": conf["read_meter1"], unit_id: conf["unit_id"]}, config)
 
     return True

--- a/custom_components/solaredge_modbus/manifest.json
+++ b/custom_components/solaredge_modbus/manifest.json
@@ -5,8 +5,7 @@
     "dependencies": [],
     "codeowners": [],
     "requirements": [
-        "pyModbusTCP >= 0.1.8",
-        "pymodbus"
+        "pymodbus>=2.4.0"
         ]
     }
     

--- a/custom_components/solaredge_modbus/meter_sensor.py
+++ b/custom_components/solaredge_modbus/meter_sensor.py
@@ -21,8 +21,8 @@ meter_values = {}
 
 class SolarEdgeMeterSensor(Entity):
     def __init__(self, client, unit_id, scan_interval):
-        _LOGGER.debug("creating modbus meter sensor")
-        print("creating modbus meter sensor")
+        _LOGGER.debug("creating modbus meter sensor #" + unit_id)
+        print("creating modbus meter sensor #" + unit_id)
 
         self._client = client
 
@@ -262,7 +262,7 @@ class SolarEdgeMeterSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "SolarEdge Modbus Meter #"
+        return "SolarEdge Modbus Meter #" + self._unit_id
 
     @property
     def should_poll(self):
@@ -281,4 +281,4 @@ class SolarEdgeMeterSensor(Entity):
 
     @property
     def unique_id(self):
-        return "SolarEdge Meter#1"
+        return "SolarEdge Meter#" + self._unit_id

--- a/custom_components/solaredge_modbus/meter_sensor.py
+++ b/custom_components/solaredge_modbus/meter_sensor.py
@@ -34,7 +34,7 @@ class SolarEdgeMeterSensor(Entity):
 
         if unit_id == 2:
             self._register_start = 40632
-        else if unit_id == 3:
+        elif unit_id == 3:
             self._register_start = 40537
 
     def round(self, floatval):

--- a/custom_components/solaredge_modbus/meter_sensor.py
+++ b/custom_components/solaredge_modbus/meter_sensor.py
@@ -17,12 +17,14 @@ from homeassistant.helpers.entity import Entity
 
 from . import DOMAIN as SOLAREDGE_DOMAIN
 
+_LOGGER = logging.getLogger(__name__)
+ICON = "mdi:power-plug"
+
 meter_values = {}
 
 class SolarEdgeMeterSensor(Entity):
     def __init__(self, client, unit_id, scan_interval):
-        _LOGGER.debug("creating modbus meter sensor #" + unit_id)
-        print("creating modbus meter sensor #" + unit_id)
+        _LOGGER.debug("creating modbus meter sensor # %id", unit_id)
 
         self._client = client
 
@@ -168,11 +170,11 @@ class SolarEdgeMeterSensor(Entity):
 
                     #40226
                     m_exported = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
+                    data.skip_bytes(12)  # Skip phases
                     
                     #40234
                     m_imported = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
+                    data.skip_bytes(12)  # Skip phases
 
                     #40095
                     m_energy_scalefactor = 10**data.decode_16bit_uint()
@@ -262,7 +264,7 @@ class SolarEdgeMeterSensor(Entity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "SolarEdge Modbus Meter #" + self._unit_id
+        return "SolarEdge Modbus Meter #" + str(self._unit_id)
 
     @property
     def should_poll(self):
@@ -281,4 +283,4 @@ class SolarEdgeMeterSensor(Entity):
 
     @property
     def unique_id(self):
-        return "SolarEdge Meter#" + self._unit_id
+        return "SolarEdge Meter#" + str(self._unit_id)

--- a/custom_components/solaredge_modbus/meter_sensor.py
+++ b/custom_components/solaredge_modbus/meter_sensor.py
@@ -1,0 +1,284 @@
+import datetime
+import asyncio
+import traceback
+
+from time import sleep
+
+from datetime import timedelta
+import logging
+
+from homeassistant.const import CONF_SCAN_INTERVAL
+
+from pyModbusTCP.client import ModbusClient
+from pymodbus.constants import Endian
+from pymodbus.payload import BinaryPayloadDecoder
+
+from homeassistant.helpers.entity import Entity
+
+from . import DOMAIN as SOLAREDGE_DOMAIN
+
+meter_values = {}
+
+class SolarEdgeMeterSensor(Entity):
+    def __init__(self, client, unit_id, scan_interval):
+        _LOGGER.debug("creating modbus meter sensor")
+        print("creating modbus meter sensor")
+
+        self._client = client
+
+        self._scan_interval = scan_interval
+        self._state = 0
+        self._device_state_attributes = {}
+        self._unit_id = unit_id
+        self._register_start = 40188
+
+        if unit_id == 2:
+            self._register_start = 40632
+        else if unit_id == 3:
+            self._register_start = 40537
+
+    def round(self, floatval):
+        return round(floatval, 2)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return self._device_state_attributes
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+
+    async def async_added_to_hass(self):
+        _LOGGER.debug("added to hass, starting loop")
+        loop = self.hass.loop
+        task = loop.create_task(self.modbus_loop())
+
+    async def modbus_loop(self):
+        while True:
+            sleep(0.005)
+            try:
+		        
+                reading = self._client.read_holding_registers(self._register_start, 107)
+                
+                if reading:
+                    data = BinaryPayloadDecoder.fromRegisters(reading, byteorder=Endian.Big, wordorder=Endian.Big)
+
+                    # Identification
+                    # 40188 C_SunSpec_DID (unit16)
+                    # 40189 C_SunSpec_Length (unit16)
+                    data.skip_bytes(4)
+
+                    # Current
+                    # #40190 - #40193
+                    m_ac_current = data.decode_16bit_int()
+                    m_ac_current_phase_a = data.decode_16bit_int()
+                    m_ac_current_phase_b = data.decode_16bit_int()
+                    m_ac_current_phase_c = data.decode_16bit_int()
+                    
+                    # #40194
+                    m_ac_current_scalefactor = 10**data.decode_16bit_int()
+
+                    meter_values['ac_current'] = self.round(m_ac_current * m_ac_current_scalefactor)
+                    meter_values['ac_current_phase_a'] = self.round(m_ac_current_phase_a * m_ac_current_scalefactor)
+                    meter_values['ac_current_phase_b'] = self.round(m_ac_current_phase_b * m_ac_current_scalefactor)
+                    meter_values['ac_current_phase_c'] = self.round(m_ac_current_phase_c * m_ac_current_scalefactor)
+
+                    ################
+                    # Voltage
+                    ################
+
+                    #40195-40198, AC Voltage LN, AB, BC and CA
+                    m_ac_voltage_phase_ln = data.decode_16bit_uint()
+                    m_ac_voltage_phase_an = data.decode_16bit_uint()
+                    m_ac_voltage_phase_bn = data.decode_16bit_uint()
+                    m_ac_voltage_phase_cn = data.decode_16bit_uint()
+
+                    #40199-40202, AC Voltage LN, AN, BN and CN
+                    m_ac_voltage_phase_ll = data.decode_16bit_uint()
+                    m_ac_voltage_phase_ab = data.decode_16bit_uint()
+                    m_ac_voltage_phase_bc = data.decode_16bit_uint()
+                    m_ac_voltage_phase_ca = data.decode_16bit_uint()
+
+                    #40203
+                    m_ac_voltage_phase_scalefactor = 10**data.decode_16bit_int()
+
+                    meter_values['ac_voltage_phase_ll'] = self.round(m_ac_voltage_phase_ll * m_ac_voltage_phase_scalefactor)
+                    meter_values['ac_voltage_phase_ab'] = self.round(m_ac_voltage_phase_ab * m_ac_voltage_phase_scalefactor)
+                    meter_values['ac_voltage_phase_bc'] = self.round(m_ac_voltage_phase_bc * m_ac_voltage_phase_scalefactor)
+                    meter_values['ac_voltage_phase_ca'] = self.round(m_ac_voltage_phase_ca * m_ac_voltage_phase_scalefactor)
+        
+                    meter_values['ac_voltage_phase_ln'] = self.round(m_ac_voltage_phase_ln * m_ac_voltage_phase_scalefactor)
+                    meter_values['ac_voltage_phase_an'] = self.round(m_ac_voltage_phase_an * m_ac_voltage_phase_scalefactor)
+                    meter_values['ac_voltage_phase_bn'] = self.round(m_ac_voltage_phase_bn * m_ac_voltage_phase_scalefactor)
+                    meter_values['ac_voltage_phase_cn'] = self.round(m_ac_voltage_phase_cn * m_ac_voltage_phase_scalefactor)
+
+                    #40204, Frequency
+                    m_ac_frequency = data.decode_16bit_int()
+
+                    ################
+                    # Power
+                    ################
+
+                    #40205
+                    m_ac_frequency_scalefactor = 10**data.decode_16bit_int()
+                    meter_values['ac_frequency'] = self.round(m_ac_frequency * m_ac_frequency_scalefactor)
+
+                    #40206
+                    m_ac_power_output = data.decode_16bit_int()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    #40210
+                    m_ac_power_scalefactor = 10**data.decode_16bit_int()
+                    meter_values['ac_power_output'] = self.round(m_ac_power_output * m_ac_power_scalefactor)
+
+                    #40211 Apparent Power
+                    m_ac_va = data.decode_16bit_uint()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    m_ac_va_scalefactor = 10 ** data.decode_16bit_int()
+                    meter_values['ac_va'] = self.round(m_ac_va * m_ac_va_scalefactor)
+
+                    #40216 Reactive Power
+                    m_ac_var = data.decode_16bit_uint()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    m_ac_var_scalefactor = 10 ** data.decode_16bit_int()
+                    meter_values['ac_var'] = self.round(m_ac_var * m_ac_var_scalefactor)
+
+                    #40221 Power Factor
+                    m_ac_pf = data.decode_16bit_uint()
+
+                    data.skip_bytes(6) # Skip the phases
+
+                    m_ac_pf_scalefactor = 10 ** data.decode_16bit_int()
+                    meter_values['ac_pf'] = self.round(m_ac_pf * m_ac_pf_scalefactor)
+
+                    ################
+                    # Accumulated Energy
+                    ################
+
+                    # Real Energy
+                    # ---------------
+
+                    #40226
+                    m_exported = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+                    
+                    #40234
+                    m_imported = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40095
+                    m_energy_scalefactor = 10**data.decode_16bit_uint()
+
+                    # Total production entire lifetime
+                    meter_values['exported'] = self.round(m_exported * m_energy_scalefactor)
+                    meter_values['imported'] = self.round(m_imported * m_energy_scalefactor)
+
+                    # Apparent Energy
+                    # ---------------
+
+                    #40243
+                    m_exported_va = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+                    
+                    #40251
+                    m_imported_va = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40259
+                    m_energy_va_scalefactor = 10**data.decode_16bit_uint()
+
+                    # Total production entire lifetime
+                    meter_values['exported_va'] = self.round(m_exported_va * m_energy_va_scalefactor)
+                    meter_values['imported_va'] = self.round(m_imported_va * m_energy_va_scalefactor)
+
+                    # Reactive Energy
+                    # ---------------
+
+                    #40260
+                    m_imported_var_q1 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+                    
+                    #40268
+                    m_imported_var_q2 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40276
+                    m_exported_var_q3 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40284
+                    m_exported_var_q4 = data.decode_32bit_uint()
+                    data.skip_bytes(12) # Skip phases
+
+                    #40293
+                    m_energy_var_scalefactor = 10**data.decode_16bit_uint()
+
+                    # Total production entire lifetime
+                    meter_values['imported_var_q1'] = self.round(m_imported_var_q1 * m_energy_var_scalefactor)
+                    meter_values['imported_var_q2'] = self.round(m_imported_var_q2 * m_energy_var_scalefactor)
+                    meter_values['exported_var_q3'] = self.round(m_exported_var_q3 * m_energy_var_scalefactor)
+                    meter_values['exported_var_q4'] = self.round(m_exported_var_q4 * m_energy_var_scalefactor)
+                    
+                    # Events
+                    # ---------------
+
+                    #40097 
+                    m_events = data.decode_32bit_uint()
+                    meter_values['events'] = m_events
+
+                    # M_EVENT_Power_Failure 0x00000004 Loss of power or phase
+                    # M_EVENT_Under_Voltage 0x00000008 Voltage below threshold (Phase Loss)
+                    # M_EVENT_Low_PF 0x00000010 Power Factor below threshold (can indicate miss-associated voltage and current inputs in three phase systems)
+                    # M_EVENT_Over_Current 0x00000020 Current Input over threshold (out of measurement range)
+                    # M_EVENT_Over_Voltage 0x00000040 Voltage Input over threshold (out of measurement range)
+                    # M_EVENT_Missing_Sensor 0x00000080 Sensor not connected
+
+                    
+                    self._state = meter_values['ac_power_output']
+                    self._device_state_attributes = meter_values
+
+                    #tell HA there is new data
+                    self.async_schedule_update_ha_state()
+                
+                
+                else:
+                    if self._client.last_error() > 0:
+                        _LOGGER.error(f'error {self._client.last_error()}')
+
+            except Exception as e:
+                _LOGGER.error(f'exception: {e}')
+                print(traceback.format_exc())
+
+            await asyncio.sleep(self._scan_interval)
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "SolarEdge Modbus Meter #"
+
+    @property
+    def should_poll(self):
+        """Return the polling state."""
+        return False
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend."""
+        return ICON
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity."""
+        return "W"
+
+    @property
+    def unique_id(self):
+        return "SolarEdge Meter#1"

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -16,6 +16,7 @@ from pymodbus.payload import BinaryPayloadDecoder
 from homeassistant.helpers.entity import Entity
 
 from . import DOMAIN as SOLAREDGE_DOMAIN
+from .meter_sensor import SolarEdgeMeterSensor
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +24,6 @@ ICON = "mdi:power-plug"
 SCAN_INTERVAL = timedelta(seconds=5)
 
 values = {}
-meter1_values = {}
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     if discovery_info is None:
@@ -32,12 +32,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.debug("fetching modbus client")
     client = hass.data.get(SOLAREDGE_DOMAIN)
     scan_interval = discovery_info[CONF_SCAN_INTERVAL]
-    useMeter1 = discovery_info["read_meter1"]
+    useMeter = discovery_info["read_meter"]
+    meterId = discovery_info["unit_id"]
 
     async_add_entities([SolarEdgeModbusSensor(client, scan_interval)], True)
 
-    if useMeter1:
-        async_add_entities([SolarEdgeMeterSensor(client, scan_interval)], True)
+    if useMeter:
+        async_add_entities([SolarEdgeMeterSensor(client, unit_id, scan_interval)], True)
 
 
 class SolarEdgeModbusSensor(Entity):
@@ -239,260 +240,3 @@ class SolarEdgeModbusSensor(Entity):
     def unique_id(self):
         return "SolarEdge"
 
-
-class SolarEdgeMeterSensor(Entity):
-    def __init__(self, client, scan_interval):
-        _LOGGER.debug("creating modbus meter#1 sensor")
-        print("creating modbus meter#1 sensor")
-
-        self._client = client
-
-        self._scan_interval = scan_interval
-        self._state = 0
-        self._device_state_attributes = {}
-
-    def round(self, floatval):
-        return round(floatval, 2)
-
-    @property
-    def device_state_attributes(self):
-        """Return the state attributes."""
-        return self._device_state_attributes
-
-    @property
-    def state(self):
-        """Return the state of the device."""
-        return self._state
-
-
-    async def async_added_to_hass(self):
-        _LOGGER.debug("added to hass, starting loop")
-        loop = self.hass.loop
-        task = loop.create_task(self.modbus_loop())
-
-    async def modbus_loop(self):
-        while True:
-            sleep(0.005)
-            try:
-		        
-                reading = self._client.read_holding_registers(40188, 107)
-                
-                if reading:
-                    data = BinaryPayloadDecoder.fromRegisters(reading, byteorder=Endian.Big, wordorder=Endian.Big)
-
-                    # Identification
-                    # 40188 C_SunSpec_DID (unit16)
-                    # 40189 C_SunSpec_Length (unit16)
-                    data.skip_bytes(4)
-
-                    # Current
-                    # #40190 - #40193
-                    m1_ac_current = data.decode_16bit_int()
-                    m1_ac_current_phase_a = data.decode_16bit_int()
-                    m1_ac_current_phase_b = data.decode_16bit_int()
-                    m1_ac_current_phase_c = data.decode_16bit_int()
-                    
-                    # #40194
-                    m1_ac_current_scalefactor = 10**data.decode_16bit_int()
-
-                    meter1_values['ac_current'] = self.round(m1_ac_current * m1_ac_current_scalefactor)
-                    meter1_values['ac_current_phase_a'] = self.round(m1_ac_current_phase_a * m1_ac_current_scalefactor)
-                    meter1_values['ac_current_phase_b'] = self.round(m1_ac_current_phase_b * m1_ac_current_scalefactor)
-                    meter1_values['ac_current_phase_c'] = self.round(m1_ac_current_phase_c * m1_ac_current_scalefactor)
-
-                    ################
-                    # Voltage
-                    ################
-
-                    #40195-40198, AC Voltage LN, AB, BC and CA
-                    m1_ac_voltage_phase_ln = data.decode_16bit_uint()
-                    m1_ac_voltage_phase_an = data.decode_16bit_uint()
-                    m1_ac_voltage_phase_bn = data.decode_16bit_uint()
-                    m1_ac_voltage_phase_cn = data.decode_16bit_uint()
-
-                    #40199-40202, AC Voltage LN, AN, BN and CN
-                    m1_ac_voltage_phase_ll = data.decode_16bit_uint()
-                    m1_ac_voltage_phase_ab = data.decode_16bit_uint()
-                    m1_ac_voltage_phase_bc = data.decode_16bit_uint()
-                    m1_ac_voltage_phase_ca = data.decode_16bit_uint()
-
-                    #40203
-                    m1_ac_voltage_phase_scalefactor = 10**data.decode_16bit_int()
-
-                    meter1_values['ac_voltage_phase_ll'] = self.round(m1_ac_voltage_phase_ll * m1_ac_voltage_phase_scalefactor)
-                    meter1_values['ac_voltage_phase_ab'] = self.round(m1_ac_voltage_phase_ab * m1_ac_voltage_phase_scalefactor)
-                    meter1_values['ac_voltage_phase_bc'] = self.round(m1_ac_voltage_phase_bc * m1_ac_voltage_phase_scalefactor)
-                    meter1_values['ac_voltage_phase_ca'] = self.round(m1_ac_voltage_phase_ca * m1_ac_voltage_phase_scalefactor)
-        
-                    meter1_values['ac_voltage_phase_ln'] = self.round(m1_ac_voltage_phase_ln * m1_ac_voltage_phase_scalefactor)
-                    meter1_values['ac_voltage_phase_an'] = self.round(m1_ac_voltage_phase_an * m1_ac_voltage_phase_scalefactor)
-                    meter1_values['ac_voltage_phase_bn'] = self.round(m1_ac_voltage_phase_bn * m1_ac_voltage_phase_scalefactor)
-                    meter1_values['ac_voltage_phase_cn'] = self.round(m1_ac_voltage_phase_cn * m1_ac_voltage_phase_scalefactor)
-
-                    #40204, Frequency
-                    m1_ac_frequency = data.decode_16bit_int()
-
-                    ################
-                    # Power
-                    ################
-
-                    #40205
-                    m1_ac_frequency_scalefactor = 10**data.decode_16bit_int()
-                    meter1_values['ac_frequency'] = self.round(m1_ac_frequency * m1_ac_frequency_scalefactor)
-
-                    #40206
-                    m1_ac_power_output = data.decode_16bit_int()
-
-                    data.skip_bytes(6) # Skip the phases
-
-                    #40210
-                    m1_ac_power_scalefactor = 10**data.decode_16bit_int()
-                    meter1_values['ac_power_output'] = self.round(m1_ac_power_output * m1_ac_power_scalefactor)
-
-                    #40211 Apparent Power
-                    m1_ac_va = data.decode_16bit_uint()
-
-                    data.skip_bytes(6) # Skip the phases
-
-                    m1_ac_va_scalefactor = 10 ** data.decode_16bit_int()
-                    meter1_values['ac_va'] = self.round(m1_ac_va * m1_ac_va_scalefactor)
-
-                    #40216 Reactive Power
-                    m1_ac_var = data.decode_16bit_uint()
-
-                    data.skip_bytes(6) # Skip the phases
-
-                    m1_ac_var_scalefactor = 10 ** data.decode_16bit_int()
-                    meter1_values['ac_var'] = self.round(m1_ac_var * m1_ac_var_scalefactor)
-
-                    #40221 Power Factor
-                    m1_ac_pf = data.decode_16bit_uint()
-
-                    data.skip_bytes(6) # Skip the phases
-
-                    m1_ac_pf_scalefactor = 10 ** data.decode_16bit_int()
-                    meter1_values['ac_pf'] = self.round(m1_ac_pf * m1_ac_pf_scalefactor)
-
-                    ################
-                    # Accumulated Energy
-                    ################
-
-                    # Real Energy
-                    # ---------------
-
-                    #40226
-                    m1_exported = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-                    
-                    #40234
-                    m1_imported = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-
-                    #40095
-                    m1_energy_scalefactor = 10**data.decode_16bit_uint()
-
-                    # Total production entire lifetime
-                    meter1_values['exported'] = self.round(m1_exported * m1_energy_scalefactor)
-                    meter1_values['imported'] = self.round(m1_imported * m1_energy_scalefactor)
-
-                    # Apparent Energy
-                    # ---------------
-
-                    #40243
-                    m1_exported_va = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-                    
-                    #40251
-                    m1_imported_va = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-
-                    #40259
-                    m1_energy_va_scalefactor = 10**data.decode_16bit_uint()
-
-                    # Total production entire lifetime
-                    meter1_values['exported_va'] = self.round(m1_exported_va * m1_energy_va_scalefactor)
-                    meter1_values['imported_va'] = self.round(m1_imported_va * m1_energy_va_scalefactor)
-
-                    # Reactive Energy
-                    # ---------------
-
-                    #40260
-                    m1_imported_var_q1 = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-                    
-                    #40268
-                    m1_imported_var_q2 = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-
-                    #40276
-                    m1_exported_var_q3 = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-
-                    #40284
-                    m1_exported_var_q4 = data.decode_32bit_uint()
-                    data.skip_bytes(12) # Skip phases
-
-                    #40293
-                    m1_energy_var_scalefactor = 10**data.decode_16bit_uint()
-
-                    # Total production entire lifetime
-                    meter1_values['imported_var_q1'] = self.round(m1_imported_var_q1 * m1_energy_var_scalefactor)
-                    meter1_values['imported_var_q2'] = self.round(m1_imported_var_q2 * m1_energy_var_scalefactor)
-                    meter1_values['exported_var_q3'] = self.round(m1_exported_var_q3 * m1_energy_var_scalefactor)
-                    meter1_values['exported_var_q4'] = self.round(m1_exported_var_q4 * m1_energy_var_scalefactor)
-                    
-                    # Events
-                    # ---------------
-
-                    #40097 
-                    m1_events = data.decode_32bit_uint()
-                    meter1_values['events'] = m1_events
-
-                    # M_EVENT_Power_Failure 0x00000004 Loss of power or phase
-                    # M_EVENT_Under_Voltage 0x00000008 Voltage below threshold (Phase Loss)
-                    # M_EVENT_Low_PF 0x00000010 Power Factor below threshold (can indicate miss-associated voltage and current inputs in three phase systems)
-                    # M_EVENT_Over_Current 0x00000020 Current Input over threshold (out of measurement range)
-                    # M_EVENT_Over_Voltage 0x00000040 Voltage Input over threshold (out of measurement range)
-                    # M_EVENT_Missing_Sensor 0x00000080 Sensor not connected
-
-                    
-                    self._state = meter1_values['ac_power_output']
-                    self._device_state_attributes = meter1_values
-
-                    #tell HA there is new data
-                    self.async_schedule_update_ha_state()
-                
-                
-                else:
-                    if self._client.last_error() > 0:
-                        _LOGGER.error(f'error {self._client.last_error()}')
-
-            except Exception as e:
-                _LOGGER.error(f'exception: {e}')
-                print(traceback.format_exc())
-
-            await asyncio.sleep(self._scan_interval)
-
-    @property
-    def name(self):
-        """Return the name of the sensor."""
-        return "SolarEdge Modbus Meter #1"
-
-    @property
-    def should_poll(self):
-        """Return the polling state."""
-        return False
-
-    @property
-    def icon(self):
-        """Return the icon to use in the frontend."""
-        return ICON
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity."""
-        return "W"
-
-    @property
-    def unique_id(self):
-        return "SolarEdge Meter#1"

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -32,13 +32,20 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     _LOGGER.debug("fetching modbus client")
     client = hass.data.get(SOLAREDGE_DOMAIN)
     scan_interval = discovery_info[CONF_SCAN_INTERVAL]
-    useMeter = discovery_info["read_meter"]
-    meterId = discovery_info["unit_id"]
+    useMeter1 = discovery_info["read_meter1"]
+    useMeter2 = discovery_info["read_meter2"]
+    useMeter3 = discovery_info["read_meter3"]
 
     async_add_entities([SolarEdgeModbusSensor(client, scan_interval)], True)
 
-    if useMeter:
-        async_add_entities([SolarEdgeMeterSensor(client, unit_id, scan_interval)], True)
+    if useMeter1:
+        async_add_entities([SolarEdgeMeterSensor(client, 1, scan_interval)], True)
+
+    if useMeter2:
+        async_add_entities([SolarEdgeMeterSensor(client, 2, scan_interval)], True)
+
+    if useMeter3:
+        async_add_entities([SolarEdgeMeterSensor(client, 3, scan_interval)], True)
 
 
 class SolarEdgeModbusSensor(Entity):

--- a/custom_components/solaredge_modbus/sensor.py
+++ b/custom_components/solaredge_modbus/sensor.py
@@ -32,9 +32,9 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     client = hass.data.get(SOLAREDGE_DOMAIN)
     scan_interval = discovery_info[CONF_SCAN_INTERVAL]
     unit_id = discovery_info["unit_id"]
-    useMeter1 = discovery_info["read_meter1"]
-    useMeter2 = discovery_info["read_meter2"]
-    useMeter3 = discovery_info["read_meter3"]
+    read_meter1 = discovery_info["read_meter1"]
+    read_meter2 = discovery_info["read_meter2"]
+    read_meter3 = discovery_info["read_meter3"]
     additional_inverter_unit_id = discovery_info["additional_inverter_unit_id"]
 
     async_add_entities([SolarEdgeModbusSensor(client, unit_id, scan_interval)], True)
@@ -42,14 +42,14 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     if additional_inverter_unit_id > 0:
         async_add_entities([SolarEdgeModbusSensor(client, additional_inverter_unit_id, scan_interval)], True)
 
-    if useMeter1:
-        async_add_entities([SolarEdgeMeterSensor(client, 1, scan_interval)], True)
+    if read_meter1:
+        async_add_entities([SolarEdgeMeterSensor(client, unit_id, 1, scan_interval)], True)
 
-    if useMeter2:
-        async_add_entities([SolarEdgeMeterSensor(client, 2, scan_interval)], True)
+    if read_meter2:
+        async_add_entities([SolarEdgeMeterSensor(client, unit_id, 2, scan_interval)], True)
 
-    if useMeter3:
-        async_add_entities([SolarEdgeMeterSensor(client, 3, scan_interval)], True)
+    if read_meter3:
+        async_add_entities([SolarEdgeMeterSensor(client, unit_id, 3, scan_interval)], True)
 
 
 class SolarEdgeModbusSensor(Entity):


### PR DESCRIPTION
I've added the support for multiple inverters in the same modbus connection. This is the scenario when you have a three-phase inverter for photovoltaic and you also have a battery, which is driven by a single-phase inverter.
You cannot open multiple connection to the different inverters, instead you have to use one connection and use the unit_id to read from the other inverter.
I've used the `ModbusTCPClient` from pymodbus, which is supporting the unit_id in the `read_holding_registers`.
I've also modified the reference to the meter using `meter_id` instead of `unit_id`, because the unit_id has to reference to the main inverter's unit_id.