### PR TITLE
Update __init__.py --> Fix for Homeassistant Error in 2024.1.0 --> "TypeError: host must be a str"

### DIFF
--- a/custom_components/solaredge_modbus/__init__.py
+++ b/custom_components/solaredge_modbus/__init__.py
@@ -33,7 +33,7 @@ async def async_setup(hass, config):
     host = conf[CONF_HOST]
     port = conf["port"]
 
-    client = ModbusClient(host, port=port, unit_id=1, auto_open=True)
+    client = ModbusClient(str(host), port=port, unit_id=1, auto_open=True)
     hass.data[DOMAIN] = client
 
     _LOGGER.debug("creating modbus client done")


### PR DESCRIPTION
Fix Error with Homeassistant Version 2024.1.0: "TypeError: host must be a str"
Fixes: #55, #56, #57